### PR TITLE
add some more documentation for issues found while working with docker native

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,36 @@
    allows the docker containers to communicate with the host machine on the
    specified ip address.
 
-   ```bash
-   sudo ifconfig lo0 alias 172.16.123.1
+   Create the following file at `/usr/local/bin/login-script`:
+   ```
+   #!/bin/sh
+
+   # add a local loopback alias for docker
+   ifconfig lo0 alias 172.16.123.1
    ```
 
-3. You're done! consider installing the docker-compose aliases to make your life
+   Then run the following commands:
+   ```
+   sudo chmod +x /usr/local/bin/login-script
+   sudo defaults write com.apple.loginwindow LoginHook /usr/local/bin/login-script
+   ```
+
+3. Modify the RabbitMQ configuration file to allow connections from any host (i.e. docker containers)
+
+  ```
+  # in /usr/local/etc/rabbitmq/rabbitmq-env.conf find and modify the following line
+  NODE_IP_ADDRESS=0.0.0.0
+  ```
+
+  And also allow non-localhost connections for the guest user
+
+  ```
+  sudo sh -c 'echo "[{rabbit, [{loopback_users, []}]}]." > /usr/local/etc/rabbitmq/rabbitmq.config'
+  ```
+
+3. Restart your computer
+
+4. You're done! consider installing the docker-compose aliases to make your life
    much easier when working with docker.
 
    Your docker containers will be available through `localhost`


### PR DESCRIPTION
The local loopback alias does not survive a system restart so we have to have it added on startup after networking has been initialized.

I tried using `/etc/rc.common` but that doesn't seem to work, probably this script is executed before networking is initialized.

Also tried a `/etc/IPAliases.conf` which google suggested but I think this feature is only for the server edition of OSX so - no dice

Also found out that by default rabbitmq doesn't accept connections that originate from off of localhost.
