### PR TITLE
improve instructions for easier migration to docker-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
    #!/bin/sh
 
    # add a local loopback alias for docker
-   ifconfig lo0 alias 172.16.123.1
+   ifconfig lo0 alias 10.0.2.2
    ```
 
    Then run the following commands:


### PR DESCRIPTION
this is a D'OH moment for sure - to straddle both docker-virtualbox and docker-native on OSX why not keep the same IP address? makes it much easier.
