### PR TITLE
Adding nano editor

### DIFF
--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -5,4 +5,5 @@ RUN bundle config --global frozen 1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     postgresql-client \
+    nano \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Why:

It would help to be able to edit some of our scripts on the fly.

This change addresses the need by:

Giving us an editor to actually do that.
